### PR TITLE
Fix clojure.string/join call

### DIFF
--- a/src/leiningen/scm_source.clj
+++ b/src/leiningen/scm_source.clj
@@ -9,7 +9,7 @@
   [& cmd]
   (let [result (apply sh/sh cmd)]
     (when-not (zero? (:exit result))
-      (throw (IllegalStateException. (str (apply string/join " " cmd) " exited with " (:exit result) ": " (:err result)))))
+      (throw (IllegalStateException. (str (string/join " " cmd) " exited with " (:exit result) ": " (:err result)))))
     (string/trim (:out result))))
 
 (defn- write [target-path content]


### PR DESCRIPTION
If the plugin fails to execute a command, it will throw

```

clojure.lang.ArityException: Wrong number of args (5) passed to: string/join
```

instead of:

```
java.lang.IllegalStateException: git config --get remote.origin.url exited with 1:
```

what it is supposed to.
